### PR TITLE
Refresh `swipe` on resize

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ function afterMount({props}, el) {
 	const {arrows, duration, fastThreshold, interval, onChange, play, threshold} = props;
 	const swipe = new Swipe(el);
 
+	window.addEventListener('resize', () => swipe.refresh());
+
 	swipe.on('show', (i, el) => {
 		if (onChange) {
 			onChange(el, i);


### PR DESCRIPTION
Resizing the window needs to refresh `swipe` to get the correct size for the carousel.
